### PR TITLE
(PUP-4067) Add environment.conf to the default environment

### DIFF
--- a/wix/puppet.wxs
+++ b/wix/puppet.wxs
@@ -360,6 +360,7 @@
             <Directory Id="EnvironmentsDir" Name="environments">
               <Component Id="EnvironmentsDir" Permanent="yes" Guid="6a6a390a-8783-40b6-b49d-9e2b368e069d">
                 <CreateFolder />
+                <File Id="EnvironmentConf" KeyPath="yes" Source="stagedir\puppet\conf\environment.conf" />
               </Component>
               <Directory Id="ProductionDir" Name="production">
                 <Component Id="ProductionDir" Permanent="yes" Guid="b902efcd-756e-4340-8f13-5a79d46b93c7">


### PR DESCRIPTION
This commit adds a well annotated example environment.conf to the
default production environment that is laid down in the puppet-agent
package so that users will be familiar with what options they have to
customize their environments.
